### PR TITLE
Feat/#5 Create broadcast

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.kafka:spring-kafka'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/http/방송.http
+++ b/http/방송.http
@@ -1,0 +1,9 @@
+### 방송 생성
+POST http://localhost:8080/broadcast
+Content-Type: application/json
+
+{
+  "title": "맛있는 선산곱창 90% 할인",
+  "code": "1234abcdqwer834f",
+  "product_id": 1
+}

--- a/src/main/java/com/example/livealone/broadcast/controller/BroadcastController.java
+++ b/src/main/java/com/example/livealone/broadcast/controller/BroadcastController.java
@@ -1,0 +1,39 @@
+package com.example.livealone.broadcast.controller;
+
+import com.example.livealone.broadcast.dto.BroadcastRequestDto;
+import com.example.livealone.broadcast.service.BroadcastService;
+import com.example.livealone.global.dto.CommonResponseDto;
+import com.example.livealone.global.security.UserDetailsImpl;
+import com.example.livealone.user.entity.Social;
+import com.example.livealone.user.entity.User;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class BroadcastController {
+
+  private final BroadcastService broadcastService;
+
+  @PostMapping("/broadcast")
+  public ResponseEntity<CommonResponseDto<BroadcastRequestDto>> addBoard(
+      @Valid @RequestBody BroadcastRequestDto boardRequestDto/*, @AuthenticationPrincipal UserDetailsImpl userPrincipal*/) {
+
+    broadcastService.createBroadcast(boardRequestDto/*, user*/);
+
+    return ResponseEntity.status(HttpStatus.CREATED).body(
+        new CommonResponseDto<>(
+        HttpStatus.CREATED.value(),
+        "방송을 성공적으로 시작하였습니다.",
+        null)
+    );
+
+  }
+
+}

--- a/src/main/java/com/example/livealone/broadcast/dto/BroadcastRequestDto.java
+++ b/src/main/java/com/example/livealone/broadcast/dto/BroadcastRequestDto.java
@@ -1,0 +1,24 @@
+package com.example.livealone.broadcast.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class BroadcastRequestDto {
+
+  @NotBlank(message = "방송 제목을 입력해주세요.")
+  @Size(max = 50, message = "제목은 최대 50글자까지 입력할 수 있습니다.")
+  private String title;
+
+  @NotBlank(message = "방송 코드를 입력해주세요.")
+  @Size(min = 16, max = 16, message = "방송 코드는 16글자여야 합니다.")
+  private String code;
+
+  @NotNull
+  private Long productId;
+
+}

--- a/src/main/java/com/example/livealone/broadcast/mapper/BroadcastMapper.java
+++ b/src/main/java/com/example/livealone/broadcast/mapper/BroadcastMapper.java
@@ -1,0 +1,22 @@
+package com.example.livealone.broadcast.mapper;
+
+import com.example.livealone.broadcast.entity.Broadcast;
+import com.example.livealone.broadcast.entity.BroadcastCode;
+import com.example.livealone.broadcast.entity.BroadcastStatus;
+import com.example.livealone.product.entity.Product;
+import com.example.livealone.user.entity.User;
+
+public class BroadcastMapper {
+
+  public static Broadcast toBroadcast(String title, User streamer, Product product, BroadcastCode broadcastCode) {
+    return Broadcast.builder()
+        .title(title)
+        .broadcastStatus(BroadcastStatus.ONAIR)
+        .broadcastCode(broadcastCode)
+        .streamer(streamer)
+        .product(product)
+        .broadcastCode(broadcastCode)
+        .build();
+  }
+
+}

--- a/src/main/java/com/example/livealone/broadcast/repository/BroadcastCodeRepository.java
+++ b/src/main/java/com/example/livealone/broadcast/repository/BroadcastCodeRepository.java
@@ -1,0 +1,10 @@
+package com.example.livealone.broadcast.repository;
+
+import com.example.livealone.broadcast.entity.BroadcastCode;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BroadcastCodeRepository extends JpaRepository<BroadcastCode, Long> {
+
+  Optional<BroadcastCode> findByCode(String code);
+}

--- a/src/main/java/com/example/livealone/broadcast/repository/BroadcastRepository.java
+++ b/src/main/java/com/example/livealone/broadcast/repository/BroadcastRepository.java
@@ -1,4 +1,8 @@
 package com.example.livealone.broadcast.repository;
 
-public class BroadcastRepository {
+import com.example.livealone.broadcast.entity.Broadcast;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BroadcastRepository extends JpaRepository<Broadcast, Long> {
+  
 }

--- a/src/main/java/com/example/livealone/broadcast/service/BroadcastService.java
+++ b/src/main/java/com/example/livealone/broadcast/service/BroadcastService.java
@@ -1,0 +1,94 @@
+package com.example.livealone.broadcast.service;
+
+import com.example.livealone.broadcast.dto.BroadcastRequestDto;
+import com.example.livealone.broadcast.entity.Broadcast;
+import com.example.livealone.broadcast.entity.BroadcastCode;
+import com.example.livealone.broadcast.mapper.BroadcastMapper;
+import com.example.livealone.broadcast.repository.BroadcastCodeRepository;
+import com.example.livealone.broadcast.repository.BroadcastRepository;
+import com.example.livealone.global.exception.CustomException;
+import com.example.livealone.product.entity.Product;
+import com.example.livealone.product.repository.ProductRepository;
+import com.example.livealone.user.entity.Social;
+import com.example.livealone.user.entity.User;
+import com.example.livealone.user.repository.UserRepository;
+import java.time.LocalDateTime;
+import java.util.Locale;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.MessageSource;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BroadcastService {
+
+  private final BroadcastRepository broadcastRepository;
+  private final BroadcastCodeRepository broadcastCodeRepository;
+  private final ProductRepository productRepository;
+  private final MessageSource messageSource;
+
+  private static final int BROADCAST_BEFORE_STARTING = 10;
+  private static final int BROADCAST_AFTER_STARTING = 60;
+  private final UserRepository userRepository;
+
+  public void createBroadcast(BroadcastRequestDto boardRequestDto/*, User user*/) {
+
+    BroadcastCode code = broadcastCodeRepository.findByCode(boardRequestDto.getCode()).orElseThrow(
+        () -> new CustomException(messageSource.getMessage(
+            "broadcast.code.not.found",
+            null,
+            CustomException.DEFAULT_ERROR_MESSAGE,
+            Locale.getDefault()
+        ), HttpStatus.NOT_FOUND)
+    );
+
+    if(!isWithinBroadcastTime(code.getAirTime(), LocalDateTime.now())) {
+      throw new CustomException(messageSource.getMessage(
+          "not.air.time",
+          null,
+          CustomException.DEFAULT_ERROR_MESSAGE,
+          Locale.getDefault()
+      ), HttpStatus.FORBIDDEN);
+    }
+
+//    Product product = productRepository.findById(boardRequestDto.getProductId()).orElseThrow(
+//        () -> new CustomException(messageSource.getMessage(
+//          "product.not.found",
+//          null,
+//          CustomException.DEFAULT_ERROR_MESSAGE,
+//          Locale.getDefault()
+//        ), HttpStatus.NOT_FOUND)
+//    );
+
+    // 더미 유저 등록 입니다. 삭제 예정.
+    User user = User.builder()
+        .username("홍길동")
+        .email("test@gmail.com")
+        .social(Social.NAVER)
+        .build();
+    userRepository.save(user);
+
+    // 더미 상품 등록 입니다. 삭제 예정.
+    Product product = Product.builder()
+        .name("이름")
+        .introduction("설명")
+        .price(10000)
+        .quantity(99L)
+        .seller(user)
+        .build();
+    productRepository.save(product);
+
+    Broadcast broadcast = BroadcastMapper.toBroadcast(boardRequestDto.getTitle(), user, product, code);
+    broadcastRepository.save(broadcast);
+
+  }
+
+  private boolean isWithinBroadcastTime(LocalDateTime airTime, LocalDateTime now) {
+
+    return now.isAfter(airTime.minusMinutes(BROADCAST_BEFORE_STARTING)) &&
+        now.isBefore(airTime.plusMinutes(BROADCAST_AFTER_STARTING));
+
+  }
+
+}

--- a/src/main/java/com/example/livealone/order/entity/Order.java
+++ b/src/main/java/com/example/livealone/order/entity/Order.java
@@ -23,7 +23,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor
-@Table(name = "broadcasts")
+@Table(name = "orders")
 public class Order extends Timestamp {
 
 	@Id

--- a/src/main/java/com/example/livealone/user/entity/User.java
+++ b/src/main/java/com/example/livealone/user/entity/User.java
@@ -1,5 +1,7 @@
 package com.example.livealone.user.entity;
 
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
@@ -35,6 +37,7 @@ public class User extends Timestamp {
 	private String email;
 
 	@Column(nullable = false)
+	@Enumerated(EnumType.STRING)
 	private Social social;
 
 	private LocalDate birthDay;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -16,6 +16,9 @@ spring:
         format_sql: true
         use_sql_comments: true
 
+  jackson:
+    property-naming-strategy: SNAKE_CASE
+
   # OAuth ???
   security:
     oauth2:

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,1 +1,9 @@
+# user
 user.not.found=유저를 찾을 수 없습니다.
+
+# broadcast
+broadcast.code.not.found=방송 코드를 잘못 입력하였습니다.
+not.air.time=현재 방송 시간이 아닙니다.
+
+# product
+product.not.found=상품을 찾을 수 없습니다.


### PR DESCRIPTION
## 🔨 작업 내용

🔨 ADD
    - 방송 시작 API 구현 (더미 product, user 사용)
    - validation 의존성 추가
    - 테스트를 위해 http 파일 추가
    - application.yaml 파일에 property-naming-strategy: SNAKE_CASE 추가 (DTO 필드 카멜 케이스를 json 파싱 시 스네이크 케이스로 변환)

🩹 FIX
    - Order Entity 테이블 이름 수정
  
<br/>

## 🍻  실행된 화면(postman에서 테스트한 것 캡쳐해서 올려주세요 성공, 예외처리되는것까지)

- 
![image](https://github.com/user-attachments/assets/c6045f7e-63dd-41ab-bf0a-6f6ed1a2c872)

- 
![image](https://github.com/user-attachments/assets/da1af1f0-9b66-420a-b969-bf2cf4e9bcab)

-
![image](https://github.com/user-attachments/assets/23acfe26-4f98-47ba-a379-9b2d3158ed91)

<br/>

## 🔎   앞으로의 과제

- bean validation 예외 핸들러는 채민님이 만들어 주신다고 합니다.

- 프론트 붙은 뒤 더미가 아닌 실제 user 받는 테스트 필요

- messageSource를 적용하다 보니 에러 발생 시키는 코드가 길어지는 것 같아 신경 쓰입니다. 리팩토링 할 수 있는 방법이 있을까요?


  <br/>
