### PR TITLE
✨ Feature/#11 유저 방송 내역 조회 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,12 @@ repositories {
 }
 
 dependencies {
+    // Query DSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'

--- a/http/방송.http
+++ b/http/방송.http
@@ -7,3 +7,7 @@ Content-Type: application/json
   "code": "1234abcdqwer834f",
   "product_id": 1
 }
+
+### 방송 내역 조회
+GET http://localhost:8080/user/broadcast
+Content-Type: application/json

--- a/src/main/java/com/example/livealone/broadcast/controller/BroadcastController.java
+++ b/src/main/java/com/example/livealone/broadcast/controller/BroadcastController.java
@@ -1,18 +1,18 @@
 package com.example.livealone.broadcast.controller;
 
 import com.example.livealone.broadcast.dto.BroadcastRequestDto;
+import com.example.livealone.broadcast.dto.BroadcastResponseDto;
 import com.example.livealone.broadcast.service.BroadcastService;
 import com.example.livealone.global.dto.CommonResponseDto;
-import com.example.livealone.global.security.UserDetailsImpl;
-import com.example.livealone.user.entity.Social;
-import com.example.livealone.user.entity.User;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -22,7 +22,7 @@ public class BroadcastController {
   private final BroadcastService broadcastService;
 
   @PostMapping("/broadcast")
-  public ResponseEntity<CommonResponseDto<BroadcastRequestDto>> addBoard(
+  public ResponseEntity<CommonResponseDto<Void>> createBroadcast(
       @Valid @RequestBody BroadcastRequestDto boardRequestDto/*, @AuthenticationPrincipal UserDetailsImpl userPrincipal*/) {
 
     broadcastService.createBroadcast(boardRequestDto/*, user*/);
@@ -32,6 +32,21 @@ public class BroadcastController {
         HttpStatus.CREATED.value(),
         "방송을 성공적으로 시작하였습니다.",
         null)
+    );
+
+  }
+
+  @GetMapping("/user/broadcast")
+  public ResponseEntity<CommonResponseDto<List<BroadcastResponseDto>>> getBroadcast(
+      @RequestParam(defaultValue = "1") int page
+      /*, @AuthenticationPrincipal UserDetailsImpl userPrincipal*/) {
+
+    return ResponseEntity.status(HttpStatus.OK).body(
+        new CommonResponseDto<>(
+            HttpStatus.OK.value(),
+            "방송 내역이 성공적으로 조회되었습니다.",
+            broadcastService.getBroadcast(page - 1/*, user*/)
+        )
     );
 
   }

--- a/src/main/java/com/example/livealone/broadcast/dto/BroadcastResponseDto.java
+++ b/src/main/java/com/example/livealone/broadcast/dto/BroadcastResponseDto.java
@@ -1,0 +1,31 @@
+package com.example.livealone.broadcast.dto;
+
+import com.example.livealone.broadcast.entity.BroadcastStatus;
+import com.querydsl.core.annotations.QueryProjection;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class BroadcastResponseDto {
+
+  private String title;
+
+  private BroadcastStatus status;
+
+  private String productName;
+
+  private LocalDateTime airTime;
+
+  @QueryProjection
+  public BroadcastResponseDto(String title, BroadcastStatus status, String productName, LocalDateTime airTime) {
+
+   this.title = title;
+   this.status = status;
+   this.productName = productName;
+   this.airTime = airTime;
+
+  }
+
+}

--- a/src/main/java/com/example/livealone/broadcast/repository/BroadcastRepository.java
+++ b/src/main/java/com/example/livealone/broadcast/repository/BroadcastRepository.java
@@ -3,6 +3,6 @@ package com.example.livealone.broadcast.repository;
 import com.example.livealone.broadcast.entity.Broadcast;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface BroadcastRepository extends JpaRepository<Broadcast, Long> {
+public interface BroadcastRepository extends JpaRepository<Broadcast, Long>, BroadcastRepositoryQuery {
   
 }

--- a/src/main/java/com/example/livealone/broadcast/repository/BroadcastRepositoryQuery.java
+++ b/src/main/java/com/example/livealone/broadcast/repository/BroadcastRepositoryQuery.java
@@ -1,0 +1,10 @@
+package com.example.livealone.broadcast.repository;
+
+import com.example.livealone.broadcast.dto.BroadcastResponseDto;
+import java.util.List;
+
+public interface BroadcastRepositoryQuery {
+
+  List<BroadcastResponseDto> findAllByUserId(Long userId, int page, int size);
+
+}

--- a/src/main/java/com/example/livealone/broadcast/repository/BroadcastRepositoryQueryImpl.java
+++ b/src/main/java/com/example/livealone/broadcast/repository/BroadcastRepositoryQueryImpl.java
@@ -1,0 +1,38 @@
+package com.example.livealone.broadcast.repository;
+
+import static com.example.livealone.broadcast.entity.QBroadcast.broadcast;
+
+import com.example.livealone.broadcast.dto.BroadcastResponseDto;
+import com.example.livealone.broadcast.dto.QBroadcastResponseDto;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class BroadcastRepositoryQueryImpl implements BroadcastRepositoryQuery {
+
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public List<BroadcastResponseDto> findAllByUserId(Long userId, int page, int size) {
+
+    return queryFactory.select(new QBroadcastResponseDto(
+          broadcast.title,
+          broadcast.broadcastStatus,
+          broadcast.product.name,
+          broadcast.broadcastCode.airTime
+        ))
+        .from(broadcast)
+        .where(broadcast.streamer.id.eq(userId))
+        .offset(page)
+        .orderBy(new OrderSpecifier<>(Order.DESC, broadcast.createdAt))
+        .limit(size)
+        .fetch();
+
+  }
+
+}

--- a/src/main/java/com/example/livealone/broadcast/service/BroadcastService.java
+++ b/src/main/java/com/example/livealone/broadcast/service/BroadcastService.java
@@ -1,6 +1,7 @@
 package com.example.livealone.broadcast.service;
 
 import com.example.livealone.broadcast.dto.BroadcastRequestDto;
+import com.example.livealone.broadcast.dto.BroadcastResponseDto;
 import com.example.livealone.broadcast.entity.Broadcast;
 import com.example.livealone.broadcast.entity.BroadcastCode;
 import com.example.livealone.broadcast.mapper.BroadcastMapper;
@@ -13,6 +14,7 @@ import com.example.livealone.user.entity.Social;
 import com.example.livealone.user.entity.User;
 import com.example.livealone.user.repository.UserRepository;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Locale;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.MessageSource;
@@ -26,11 +28,14 @@ public class BroadcastService {
   private final BroadcastRepository broadcastRepository;
   private final BroadcastCodeRepository broadcastCodeRepository;
   private final ProductRepository productRepository;
+  private final UserRepository userRepository;
+
   private final MessageSource messageSource;
 
   private static final int BROADCAST_BEFORE_STARTING = 10;
   private static final int BROADCAST_AFTER_STARTING = 60;
-  private final UserRepository userRepository;
+
+  private static final int PAGE_SIZE = 10;
 
   public void createBroadcast(BroadcastRequestDto boardRequestDto/*, User user*/) {
 
@@ -81,6 +86,13 @@ public class BroadcastService {
 
     Broadcast broadcast = BroadcastMapper.toBroadcast(boardRequestDto.getTitle(), user, product, code);
     broadcastRepository.save(broadcast);
+
+  }
+
+  public List<BroadcastResponseDto> getBroadcast(int page/*, User user*/) {
+
+    // 현재 user 를 가져올 수 없어 일단 임의로 user id를 입력하였습니다. 이후 변경 예정
+    return broadcastRepository.findAllByUserId(1L, page, PAGE_SIZE);
 
   }
 

--- a/src/main/java/com/example/livealone/global/config/JPAConfig.java
+++ b/src/main/java/com/example/livealone/global/config/JPAConfig.java
@@ -1,0 +1,19 @@
+package com.example.livealone.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JPAConfig {
+
+  @PersistenceContext
+  private EntityManager entityManager;
+
+  @Bean
+  public JPAQueryFactory jpaQueryFactory() {
+    return new JPAQueryFactory(entityManager);
+  }
+}


### PR DESCRIPTION
## 🔨 작업 내용

🔨 ADD
    - QueryDSL 의존성, config 추가
    - 유저 방송 내역 조회 기능 구현

🩹 FIX
    - 방송 추가 코드 수정: 메서드 명, 반환값 잘못 됨
  
<br/>

## 🍻  실행된 화면(postman에서 테스트한 것 캡쳐해서 올려주세요 성공, 예외처리되는것까지)

- 
![캡처1](https://github.com/user-attachments/assets/cbc995f7-fb30-47fe-ad5c-fcd0f39004b5)


<br/>

## 🔎   앞으로의 과제

- user 구현 되면 고치기

- 조회할 것이 없을 때 예외 처리는 따로 넣지 않았습니다. 프론트 만들면서 필요하면 추후 추가.
