### PR TITLE
feat/#29-social-login-cors

### DIFF
--- a/src/main/java/com/example/livealone/global/config/CorsConfig.java
+++ b/src/main/java/com/example/livealone/global/config/CorsConfig.java
@@ -1,0 +1,27 @@
+package com.example.livealone.global.config;
+
+import java.util.List;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(List.of("http://localhost:3000"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("Authorization", "Content-Type"));
+        configuration.setAllowCredentials(true); // 인증 정보를 허용 JWT, 쿠키
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+
+        return source;
+    }
+}
+

--- a/src/main/java/com/example/livealone/global/security/config/WebSecurityConfig.java
+++ b/src/main/java/com/example/livealone/global/security/config/WebSecurityConfig.java
@@ -17,6 +17,7 @@ import com.example.livealone.global.security.UserDetailsServiceImpl;
 import com.example.livealone.global.security.filter.JwtAuthentication;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.cors.CorsConfigurationSource;
 
 @Configuration
 @RequiredArgsConstructor
@@ -40,10 +41,12 @@ public class WebSecurityConfig {
 	}
 
 	@Bean
-	public SecurityFilterChain securityFilterChain(final HttpSecurity http) throws Exception {
+	public SecurityFilterChain securityFilterChain(final HttpSecurity http, CorsConfigurationSource corsConfigurationSource) throws Exception {
 
 		http.csrf(AbstractHttpConfigurer::disable);
 		http.formLogin(AbstractHttpConfigurer::disable);
+
+		http.cors(cors -> cors.configurationSource(corsConfigurationSource));
 
 		http.sessionManagement(configurer -> configurer.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 

--- a/src/main/java/com/example/livealone/oauth2/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/example/livealone/oauth2/handler/OAuth2AuthenticationSuccessHandler.java
@@ -1,5 +1,6 @@
 package com.example.livealone.oauth2.handler;
 
+import java.io.IOException;
 import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -26,7 +27,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 	private final JwtService jwtService;
 
 	@Override
-	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
+	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
 
 		User user = ((UserDetailsImpl) authentication.getPrincipal()).getUser();
 
@@ -37,6 +38,9 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 		Cookie cookie = new Cookie("refresh", refreshToken);
 		cookie.setMaxAge(EXPIRE_TIME);
 		response.addCookie(cookie);
+
+		String redirectUrl = "http://localhost:3000/oauth2/redirect?token=" + accessToken;
+		response.sendRedirect(redirectUrl);
 
 	}
 


### PR DESCRIPTION
 ADD
    - OAuth2AuthenticationSuccessHandler에 redirectUrl 추가
    - Cors 설정 추가

<br/>

## 🔨 작업 내용

- OAuth2AuthenticationSuccessHandler에 redirectUrl 추가

- Cors 설정 추가


  
<br/>

## 🍻  실행된 화면(postman에서 테스트한 것 캡쳐해서 올려주세요 성공, 예외처리되는것까지)
![image](https://github.com/user-attachments/assets/2816125d-9b06-4cb3-954b-f7e58a323ccb)


<br/>

## 🔎   앞으로의 과제

- 구글, 네이버 로그인 react와 연동


  <br/>
