### PR TITLE
Fix/#44 broadcast restart

### DIFF
--- a/src/main/java/com/example/livealone/broadcast/entity/Broadcast.java
+++ b/src/main/java/com/example/livealone/broadcast/entity/Broadcast.java
@@ -55,6 +55,14 @@ public class Broadcast extends Timestamp {
 		this.broadcastCode = broadcastCode;
 	}
 
+	public Broadcast updateBroadcast(String title, User streamer, Product product) {
+		this.title = title;
+		this.broadcastStatus = BroadcastStatus.ONAIR;
+		this.streamer = streamer;
+		this.product = product;
+		return this;
+	}
+
 	public Broadcast closeBroadcast() {
 		this.broadcastStatus = BroadcastStatus.CLOSE;
 		return this;

--- a/src/main/java/com/example/livealone/global/config/CorsConfig.java
+++ b/src/main/java/com/example/livealone/global/config/CorsConfig.java
@@ -14,7 +14,7 @@ public class CorsConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowedOrigins(List.of("http://localhost:3000"));
-        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("Authorization", "Content-Type"));
         configuration.setAllowCredentials(true); // 인증 정보를 허용 JWT, 쿠키
 


### PR DESCRIPTION
## ✨  제목 : Fix/#44 broadcast restart


<br/>

## 🔨 작업 내용

 ADD
    - 방송 재시작 가능
    - 정각에 방송 강제 중단 스케쥴 추가

 FIX
    - 무조건 방송 시작 시간 + 1시간 동안만 시작 가능
    - cors에 patch 추가

  
<br/>

## 🍻  실행된 화면(postman에서 테스트한 것 캡쳐해서 올려주세요 성공, 예외처리되는것까지)

- 
![캡처](https://github.com/user-attachments/assets/78c26556-c926-4e41-9359-5bd524f7c63a)
![캡처2](https://github.com/user-attachments/assets/2e3b2bf1-822f-46ae-9298-5d28b6af4292)

<br/>

## 🔎   앞으로의 과제

- 현재 방송 중단 -> 방송 시작 할 때 상품 정보를 다시 입력하도록 하였는데 그러다 보니 product가 새로 계속 추가됩니다
  -  상품 정보 다시 입력하게 하지 않기 / 상품 수정 api 추가하기 둘 중 어느 게 좋을까요?