### PR TITLE
feat:SocketMessageType 명시적으로 알 수 있도록 세분화, ReissueRequestDto 생성자 추가(웹소…

### DIFF
--- a/src/main/java/com/example/livealone/LivealoneApplication.java
+++ b/src/main/java/com/example/livealone/LivealoneApplication.java
@@ -3,9 +3,11 @@ package com.example.livealone;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 
 @EnableJpaAuditing
+@EnableScheduling
 @SpringBootApplication
 public class LivealoneApplication {
 

--- a/src/main/java/com/example/livealone/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/example/livealone/chat/repository/ChatMessageRepository.java
@@ -3,5 +3,8 @@ package com.example.livealone.chat.repository;
 import com.example.livealone.chat.entity.ChatMessage;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
+import java.util.ArrayList;
+
 public interface ChatMessageRepository extends MongoRepository<ChatMessage,String> {
+    ArrayList<ChatMessage> findTop30ByOrderByIdDesc();
 }

--- a/src/main/java/com/example/livealone/global/entity/SocketMessageType.java
+++ b/src/main/java/com/example/livealone/global/entity/SocketMessageType.java
@@ -1,10 +1,20 @@
 package com.example.livealone.global.entity;
 
 public enum SocketMessageType {
-    AUTH,
-    MESSAGE,
+    // BACKEND
+    REQUEST_AUTH,
+    REQUEST_CHAT_INIT,
+    REQUEST_REFRESH,
+    CHAT_MESSAGE,
     FAILED,
-    INIT,
+
     ERROR,
     BROADCAST,
+
+    // FRONTEND
+    RESPONSE_AUTH,
+    RESPONSE_CHAT_INIT,
+    RESPONSE_REFRESH,
+    INVALID_TOKEN,
+    ANONYMOUS_USER,
 }

--- a/src/main/java/com/example/livealone/user/dto/ReissueRequestDto.java
+++ b/src/main/java/com/example/livealone/user/dto/ReissueRequestDto.java
@@ -1,10 +1,12 @@
 package com.example.livealone.user.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class ReissueRequestDto {
 
   private String refresh;


### PR DESCRIPTION
…켓을 통한 요청을 위해),채팅방 접속시 최근 30개 채팅이 보이도록 설정

<br/>

## ✨  제목 : 스트리머페이지 토큰 재발급 로직 추가


<br/>

## 🔨 작업 내용

- SocketMessageType명시적으로 알 수 있도록 세분화
- accessToken 재발급 로직 추가
- 리프레쉬토큰이 유효하지않으면 Anonymous유저로 진행 ( 채팅을 제외한 로직 이용 가능) 
- 첫 페이지 접속 시 최근 채팅30개 보이도록 구현


  
<br/>

## 🍻  실행된 화면(postman에서 테스트한 것 캡쳐해서 올려주세요 성공, 예외처리되는것까지)

- 
![image](https://github.com/user-attachments/assets/6aa10f95-928f-4efe-961c-c8caaf2a2f2f)


<br/>

## 🔎   앞으로의 과제

- 채팅관련 로직 리팩토링



  <br/>

