### PR TITLE
Fix/#89 fix chatting bug

### DIFF
--- a/src/main/java/com/example/livealone/chat/service/ChatService.java
+++ b/src/main/java/com/example/livealone/chat/service/ChatService.java
@@ -61,6 +61,16 @@ public class ChatService {
         });
     }
 
+    public void responseDirectMessageToSocekt(WebSocketSession session, String jsonMessage) {
+        try{
+            TextMessage text = new TextMessage(jsonMessage);
+            session.sendMessage(text);
+        }catch (IOException e){
+            log.info(e.getMessage());
+            addErrorLogs(e.getMessage());
+        }
+    }
+
     public void writeInitMessage(WebSocketSession session) {
 
         try {
@@ -160,4 +170,5 @@ public class ChatService {
         saveErrorLogs();
         saveSessionLogs();
     }
+
 }

--- a/src/main/java/com/example/livealone/global/handler/WebSocketHandler.java
+++ b/src/main/java/com/example/livealone/global/handler/WebSocketHandler.java
@@ -74,7 +74,8 @@ public class WebSocketHandler extends TextWebSocketHandler {
         switch (socketMessageDto.getType()) {
             case REQUEST_AUTH -> {
                 jsonMessage = getAuthMessage(session, socketMessageDto);
-                kafkaTemplate.send("chat", jsonMessage);
+
+                chatService.responseDirectMessageToSocekt(session,jsonMessage);
             }
             case REQUEST_REFRESH -> {
                 try{
@@ -82,19 +83,22 @@ public class WebSocketHandler extends TextWebSocketHandler {
 
                     TokenResponseDto tokenResponseDto = authService.reissueAccessToken(new ReissueRequestDto(refresh));
                     jsonMessage = getRefreshMessage(socketMessageDto, tokenResponseDto);
-                    kafkaTemplate.send("chat", jsonMessage);
+
+                    chatService.responseDirectMessageToSocekt(session,jsonMessage);
                 }catch (CustomException e){
                     SocketMessageDto anonymousUserMessage = new SocketMessageDto(ANONYMOUS_USER, "back-server", e.getMessage());
                     jsonMessage = objectMapper.writeValueAsString(anonymousUserMessage);
-                    kafkaTemplate.send("chat",jsonMessage);
+                    chatService.responseDirectMessageToSocekt(session,jsonMessage);
                 }
             }
             case CHAT_MESSAGE -> {
                 jsonMessage = message.getPayload();
+
                 kafkaTemplate.send("chat", jsonMessage);
             }
             case REQUEST_CHAT_INIT -> {
                 // kafka로 메시지를 보내지 않고, 접속한 세션에게 바로 전송
+
                 chatService.writeInitMessage(session);
             }
             case ERROR -> {

--- a/src/main/java/com/example/livealone/global/handler/WebSocketHandler.java
+++ b/src/main/java/com/example/livealone/global/handler/WebSocketHandler.java
@@ -69,7 +69,7 @@ public class WebSocketHandler extends TextWebSocketHandler {
     @Override
     protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
         SocketMessageDto socketMessageDto = getMessageType(message.getPayload());
-
+        log.info("handleTextMessage :",message.getPayload());
         String jsonMessage;
         switch (socketMessageDto.getType()) {
             case REQUEST_AUTH -> {


### PR DESCRIPTION
<br/>

## ✨  제목 : 채팅창 버그 수정


<br/>

## 🔨 작업 내용

- 토큰인증과정은 kafka를활용하는것이 아니라 session으로 직접 보내도록 수정


- 배포된 서버에서 확인하기위한 로그 적용
  
<br/>

## 🍻  실행된 화면(postman에서 테스트한 것 캡쳐해서 올려주세요 성공, 예외처리되는것까지)

- 
![image](https://github.com/user-attachments/assets/d093ec6d-fa09-4c55-9a57-4d1928d31ae7)


<br/>

## 🔎   앞으로의 과제

- 채팅이 보내지지않는 버그 수정


  <br/>


