### PR TITLE
Refactor/#117 유저 테스트를 위해 20분에 한 번 방송 종료, 방송 없을 시 default key 전달

### DIFF
--- a/src/main/java/com/example/livealone/broadcast/service/BroadcastService.java
+++ b/src/main/java/com/example/livealone/broadcast/service/BroadcastService.java
@@ -52,12 +52,15 @@ public class BroadcastService {
   private final ObjectMapper objectMapper;
   private final MessageSource messageSource;
 
-  private static final int BROADCAST_AFTER_STARTING = 60;
+  private static final int BROADCAST_AFTER_STARTING = 20;
 
   private static final int PAGE_SIZE = 5;
 
   @Value("${admin.code}")
   private String ADMIN_CODE;
+
+  @Value("${default.stream-key}")
+  private String DEFAULT_STREAM_KEY;
 
 
   public CreateBroadcastResponseDto createBroadcast(BroadcastRequestDto boardRequestDto, User user)
@@ -152,8 +155,9 @@ public class BroadcastService {
 
   /**
    * 매 정각마다 방송을 중단하고 스트림 키를 보내는 스케쥴러 입니다.
+   * 유저 테스트 용으로 0, 20, 40분에 실행 되도록 하였습니다.
    */
-  @Scheduled(cron = "0 0 * * * *")
+  @Scheduled(cron = "0 0,20,40 * * * *")
   public void forceCloseBroadcast() throws JsonProcessingException {
     broadcastRepository.findByBroadcastStatus(BroadcastStatus.ONAIR)
         .ifPresent(broadcast -> broadcastRepository.save(broadcast.closeBroadcast()));
@@ -185,7 +189,7 @@ public class BroadcastService {
     if(broadcast.isPresent()) {
       return BroadcastMapper.toStreamKeyResponseDto(true, broadcast.get().getBroadcastCode().getCode());
     } else {
-      return BroadcastMapper.toStreamKeyResponseDto(false, "");
+      return BroadcastMapper.toStreamKeyResponseDto(false, DEFAULT_STREAM_KEY);
     }
   }
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -108,6 +108,8 @@ toss:
 
 admin:
   code: ${ADMIN_CODE}
+default:
+  stream-key: ${DEFAULT_STREAM_KEY}
 
 uri:
   back-server: ${SERVER_HOST}


### PR DESCRIPTION
<br/>

## ✨  제목 : Refactor/#117 유저 테스트를 위해 20분에 한 번 방송 종료, 방송 없을 시 default key 전달


<br/>

## 🔨 작업 내용

-  FIX
    - 20분에 한 번 방송 종료
    - 방송 없을 시 default key 전달


  
<br/>

## 🍻  실행된 화면(postman에서 테스트한 것 캡쳐해서 올려주세요 성공, 예외처리되는것까지)
![image](https://github.com/user-attachments/assets/3dbb18c3-14fb-4322-b40e-5e0cc588f5e0)
![image](https://github.com/user-attachments/assets/f2e81627-5ff7-4a2f-9b63-390db05b7476)
![image](https://github.com/user-attachments/assets/57c5017b-121f-422b-8873-6320bf47f580)


- 

<br/>

## 🔎   앞으로의 과제

- 방송 없을 시 default key를 전달하는 부분은 프론트에서도 변경 해야 반영됨. 일단 오류 없이 작동합니다.

- 

- 
