### PR TITLE
Refactor/#145 distributed lock for payment

### DIFF
--- a/src/main/java/com/example/livealone/global/aop/AopForTransaction.java
+++ b/src/main/java/com/example/livealone/global/aop/AopForTransaction.java
@@ -8,7 +8,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 public class AopForTransaction {
 
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public Object proceed(ProceedingJoinPoint joinPoint) throws Throwable {
         return joinPoint.proceed();
     }

--- a/src/main/java/com/example/livealone/oauth2/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/example/livealone/oauth2/handler/OAuth2AuthenticationSuccessHandler.java
@@ -26,12 +26,14 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 
 	private final URIConfig uriConfig;
 
+	@Value("${spring.security.oauth2.redirect.url}")
+	private String url;
+
 	@Override
 	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
 
 		User user = ((UserDetailsImpl) authentication.getPrincipal()).getUser();
 
-		String url= String.format("http://livealone.shop:3000/oauth2/redirect");
 		response.sendRedirect(UriComponentsBuilder.fromHttpUrl(url)
 				.queryParam("access", jwtService.generateToken(user))
 				.queryParam("refresh", authService.reissueRefreshToken(user))

--- a/src/main/java/com/example/livealone/order/repository/OrderRepository.java
+++ b/src/main/java/com/example/livealone/order/repository/OrderRepository.java
@@ -4,7 +4,13 @@ import com.example.livealone.order.entity.Order;
 import com.example.livealone.user.entity.User;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface OrderRepository extends JpaRepository<Order,Long>, OrderRepositoryQuery {
     Optional<Order> findByUser(User user);
+
+    @Query("SELECT o FROM Order o JOIN FETCH o.product WHERE o.id = :orderId")
+    Optional<Order> findByIdWithProduct(@Param("orderId") Long orderId);
+
 }

--- a/src/main/java/com/example/livealone/payment/service/PaymentService.java
+++ b/src/main/java/com/example/livealone/payment/service/PaymentService.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import com.example.livealone.global.aop.DistributedLock;
 import com.example.livealone.global.config.URIConfig;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -399,9 +400,9 @@ public class PaymentService {
 	// 	}
 	// }
 
-	@Transactional
+	@DistributedLock(key = "'rollbackAndDeleteOrder-' + #orderId")
 	public void rollbackAndDeleteOrder(Long orderId) {
-		Order order = orderRepository.findById(orderId)
+		Order order = orderRepository.findByIdWithProduct(orderId)
 			.orElseThrow(() -> new IllegalArgumentException("Invalid order ID: " + orderId));
 		Product product = order.getProduct();
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -3,13 +3,13 @@ spring:
     name: livealone
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://${DATABASE_HOST}:3306/live_alone
+    url: jdbc:mysql://${DATABASE_HOST}:3307/live_alone
     username: ${MYSQL_USER}
     password: ${MYSQL_PASSWORD}
   data:
     redis:
       host: ${DATABASE_HOST}
-      port: 6379
+      port: 6378
     mongodb:
       uri: mongodb://${MONGO_INITDB_ROOT_USERNAME}:${MONGO_INITDB_ROOT_PASSWORD}@${DATABASE_HOST}:27017/chatdb?authSource=admin
       port: 27017
@@ -31,6 +31,8 @@ spring:
 
   security:
     oauth2:
+      redirect:
+        url: http://${FRONT_SERVER_HOST}:3000/oauth2/redirect
       client:
         registration:
           google:


### PR DESCRIPTION
<br/>

## ✨  제목 : Refactor/#145 distributed lock for payment


<br/>

## 🔨 작업 내용
- rollbackAndDeleteOrder에 Transactional 제거 -> order 조회할 때 product까지 fetchjoin으로 가져와서 Transactional 필요없게 코드 변경

- orderRepository에 findByIdWithProduct 메서드 생성

- 커넥션 풀 쓰레드 수 제한 문제로 AopForTransaction에 데이터 정합성을 위해 붙였던 REQUIES_NEW 트랜잭션 옵션 제거

<br/>

## 🍻  실행된 화면(postman에서 테스트한 것 캡쳐해서 올려주세요 성공, 예외처리되는것까지)

- 테스트 코드 통과
![image](https://github.com/user-attachments/assets/010bd917-4174-4a42-83bb-80c1660a45f7)


<br/>

## 🔎   앞으로의 과제

- 분산락을 사용하는 방식으로는 해결해뒀는데 데이터 정합성 문제가 발생한다면 비관적락으로 문제를 해결하는 방법으로 도입할지 생각


  <br/>
